### PR TITLE
Add split text to database

### DIFF
--- a/analyzer/analyzer.py
+++ b/analyzer/analyzer.py
@@ -51,7 +51,7 @@ class DocumentAnalyzer:
                     logging.info(f"Generated vector of length {len(vector)} for split")
 
                     self.split_crud.add_split_document(doc.DocID, split_start_offset, len(split),
-                                                       vector)
+                                                       vector, SplitContent=split)
                     logging.info(f"Added split document for DocID {doc.DocID}")
                     logging.info(f"Split start offset: {split_start_offset}, split length: {len(split)}")
                     split_start_offset = split_start_offset + len(split)

--- a/database_access/splitCrud.py
+++ b/database_access/splitCrud.py
@@ -31,7 +31,7 @@ dictConfig({
 })
 
 load_dotenv()
-DEBUG_SPIT_TEXT_ENABLED = os.environ.get("DEBUG_SPIT_TEXT_ENABLED", "False").lower() == "true"
+DEBUG_SPLIT_CONTENT_ENABLED = os.environ.get("DEBUG_SPLIT_CONTENT_ENABLED", "False").lower() == "true"
 assert os.environ.get("MAX_SPLITS") is not None, "You have not set MAX_SPLITS."
 assert os.environ.get("DIST_THRESHOLD") is not None, "You have not set DIST_THRESHOLD."
 
@@ -43,16 +43,16 @@ class SplitDocument(Base):
     SplitID = Column(Integer, primary_key=True, autoincrement=True)
     DocID = Column(Integer, ForeignKey('documents.DocID'))
     DateRead = Column(DateTime)
-    # SplitContent = Column(String)
+    SplitContent = Column(String)
     SplitStartOffset = Column(Integer)
     SplitLength = Column(Integer)
     #Do we need VectorStored?
     # VectorStored = Column(Boolean, default=False)
     SplitVector = Column(Vector(3072))
 
-    # Conditionally add SpitText
-    if DEBUG_SPIT_TEXT_ENABLED:
-        SpitText = Column(String, nullable=True) # Add as nullable String
+    # Conditionally add SplitContent
+    if DEBUG_SPLIT_CONTENT_ENABLED:
+        SplitContent = Column(String, nullable=True) # Add as nullable String
 
     __table_args__ = (UniqueConstraint('DocID', 'SplitStartOffset', name='_docid_splitstartoffset_uc'),)
 
@@ -64,7 +64,7 @@ class SplitCRUD:
 
 #TODO optimize to use offsets and only store the content in the documents table
     def add_split_document(self, doc_id, split_start_offset, split_length,
-                           split_vector, SpitText=None):
+                           split_vector, SplitContent=None):
         existing_split = self.session.query(SplitDocument).filter(
             SplitDocument.DocID == doc_id,
             SplitDocument.SplitStartOffset == split_start_offset
@@ -77,8 +77,8 @@ class SplitCRUD:
                 "SplitLength": split_length,
                 "SplitVector": split_vector
             }
-            if DEBUG_SPIT_TEXT_ENABLED and SpitText is not None:
-                split_doc_args["SpitText"] = SpitText
+            if DEBUG_SPLIT_CONTENT_ENABLED and SplitContent is not None:
+                split_doc_args["SplitContent"] = SplitContent
 
             new_split_doc: SplitDocument = SplitDocument(**split_doc_args)
             self.session.add(new_split_doc)


### PR DESCRIPTION
Added split text to the database to make it easier to debug - this also added a feature flag based on the environment variable DEBUG_SPLIT_CONTENT_ENABLED. 